### PR TITLE
Add an endpoint to get a specific submission by ID.

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -127,6 +127,16 @@ module.exports = function (formio) {
         return res.body;
       }.bind(this));
   };
+  
+  /**
+   * Get a particular submission by its ID.
+   */
+  Form.prototype.getSubmission = function(submissionId) {
+    return formio.request('get', this.url + '/submission/' + submissionId)
+      .then(function (res) {
+        return res.body;
+      }.bind(this));
+  };  
 
   /**
    * Retrieve all form actions.


### PR DESCRIPTION
Useful when you already have the submission ID from somewhere else.